### PR TITLE
fix: update python version to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # adding comment to kick off the image rebuild
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-RUN microdnf -y install git autoconf automake gcc libtool file diffutils make python3 python3-pip && microdnf clean all
+RUN microdnf -y install git autoconf automake gcc libtool file diffutils make python3.11 python3.11-pip && microdnf clean all
 RUN git clone --branch v2.30.0 https://github.com/intel/isa-l.git
 COPY yasm-1.3.0-7.el8.x86_64.rpm .
 RUN rpm -i yasm-1.3.0-7.el8.x86_64.rpm && rm yasm-1.3.0-7.el8.x86_64.rpm


### PR DESCRIPTION
To improve performance of insights-engine, update the python version from 3.6.8 to 3.11